### PR TITLE
Button image can now be changed after initially being set

### DIFF
--- a/WCLShineButton/WCLShineClickLayer.swift
+++ b/WCLShineButton/WCLShineClickLayer.swift
@@ -33,7 +33,7 @@ class WCLShineClickLayer: CALayer {
     
     var image: WCLShineImage = .heart {
         didSet {
-            maskLayer.contents = image.getImage()
+            maskLayer.contents = image.getImage()?.cgImage
         }
     }
     


### PR DESCRIPTION
After initially setting the button image (and layoutSublayers() being
called), subsequent changes to the image resulted in a blank view. This
fixes that issue.